### PR TITLE
Add minimal CODEOWNERS to claim the repository

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,7 +1,5 @@
-# This is a comment.
-# Each line is a file pattern followed by one or more owners.
+# We do not allow repositories that are running on CD (in this case to deploy
+# to pypi) to be claimed by single persons. This is a wide team in Value Delivery, but
+# the best fit right now until Alex Vincent (who maintains this) can get his own team!
+* @cognitedata/data-engineering
 
-# All files
-*  @vminfant
-
-# Repo is currently being maintained by a single member from Global Delivery.


### PR DESCRIPTION
This replaces Alex Vincent as sole owner of the repository, as that makes changes hard to merge when it also requires a review.

We require a clear owner-team when it runs on CD.
